### PR TITLE
Persist 4 days of forecast data

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -12,8 +12,8 @@ plugins:
   - serverless-python-requirements
   - serverless-dynamodb-pitr
   - serverless-domain-manager
-  - serverless-offline
   - serverless-dynamodb
+  - serverless-offline
 
 custom:
   statusTable: photonranch-status-${self:provider.stage}


### PR DESCRIPTION
Problem: Wayne wanted to be able to see more than 2 days of forecast data on the calendar.

Solution: Merge incoming reports with older ones up to 96 hours in the past

Changes:
- Added a function post_forecast_status() and logic to post_status_http() in handler.py that merges new incoming forecast reports and then prunes reports older than 96 hours instead of replacing them all-together.
- Also had to rearrange the plugins due to order mattering for plugins to work properly otherwise build would break.

Other Notes: 
No changes needed on the frontend as it just takes an array of forecast data and draws colors onto the calendar based on that data. So in this case since the database is storing a longer array the GET request by the frontend will retain the same behavior just with a larger array.

Solution does not check for duplicates, doesn't seem to be a problem for now. This would occur if the site forecast software posted duplicate forecast data to the photonranch-status api. The frontend ignores duplicate forecast reports when drawing and the backend deletes old forecast reports the next time new data is posted. Data is also very small, ~50 json text objects.