### PR TITLE
Added duplication filtering for forecast reports, Added Cloudwatch logging for reports, fixed bug with local dev

### DIFF
--- a/phase_status.py
+++ b/phase_status.py
@@ -15,7 +15,7 @@ except Exception as e:
 if os.getenv('IS_OFFLINE'):
     print(os.getenv('IS_OFFLINE'))
     resource = boto3.resource('dynamodb', endpoint_url='http://localhost:9000')
-    status_table = resource.Table(name='photonranch-status-dev')
+    phase_status_table = resource.Table(name='photonranch-status-dev')
 
 def post_phase_status(event, context):
     body = _get_body(event)


### PR DESCRIPTION
Problem: Forecast reports are being posted and ignored by photonranch-status. Reports older than the 96 hour data window are being displayed when they should be removed. There isn't a sure reason why yet.

Feature/Changes:
- Added duplicate report filtering to relive load on the database and in general improve performance and limit data waste. Previously new posts to api would be adding lots of duplicate data since the function didn't check for that when merging forecast report lists. Now duplicates are removed before sending data to DynamoDB

- Improved logging for aws cloudwatch debugging of forecast reports to figure out why new reports arn't being ingested.  

- Fixed bug with phase status table pointing to the wrong table for local dev

Extra Comments: 
With local testing the problem is not able to be replicated. Adding these attempted fixes as well as logging so that if the problem continues it will be much easier to debug what is happening in AWS cloudwatch logs