### PR TITLE
Fixed old datetime isoformat error and added error handling

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -121,18 +121,23 @@ def post_forecast_status(site, status_type, new_status):
     existing_status = get_status(site, status_type).get("status", {})
 
     merged_forecast = existing_status.get("forecast", []) + new_status.get("forecast", [])
-    print("Existing Forecast Length:", len(existing_status.get("forecast", [])))
-    print("New Forecast Length:", len(new_status.get("forecast", [])))
-    print("Merged Forecasts Length:", len(merged_forecast))
 
     # Variable for how far in the past we save forecast data
     forecast_data_period = timedelta(hours=96)
     
     # Filter out report objects that are older than the data retention period
-    filtered_merged_forecast = [report for report in merged_forecast if (datetime.utcnow().astimezone() - datetime.fromisoformat(report.get("utc_long_form", ""))) <= forecast_data_period]
+    filtered_merged_forecast = []
+    current_time = datetime.utcnow().astimezone()
 
-    print("Post Filter time length: ", len(filtered_merged_forecast))
-    print(', '.join(report.get("utc_long_form", "missing") for report in filtered_merged_forecast))
+    for report in merged_forecast:
+        try:
+            report_time = datetime.fromisoformat(report.get("utc_long_form", "").replace('Z', '+00:00'))
+        except Exception as e:
+            print(f"An error occured parsing isoformat from report: {report}. Error: {e}")
+            continue
+
+        if (current_time - report_time) <= forecast_data_period:
+            filtered_merged_forecast.append(report)
 
     # Removing report duplicates based on utc time
     seen_time_reports = set()
@@ -141,9 +146,6 @@ def post_forecast_status(site, status_type, new_status):
         if report.get("utc_long_form" , "") not in seen_time_reports:
             unique_filtered_merged_forecast.append(report)
             seen_time_reports.add(report.get("utc_long_form" , ""))
-
-    print("Post Duplicate removal length:", len(unique_filtered_merged_forecast))
-    print(', '.join(report.get("utc_long_form", "missing") for report in filtered_merged_forecast))
 
     merged_status = existing_status
     merged_status["forecast"] = unique_filtered_merged_forecast
@@ -165,9 +167,6 @@ def post_forecast_status(site, status_type, new_status):
 def get_status(site, status_type):
     """Retrieves status from table for a given site and status type."""
     table_response = status_table.get_item(Key={"site": site, "statusType": status_type})
-    if(status_type == 'forecast'):
-        print("get_status() forecast response length", len(table_response.get("Item" , {}).get("status").get("forecast")))
-        print(', '.join(report.get("utc_long_form") for report in table_response.get("Item" , {}).get("status").get("forecast")))
     return table_response.get("Item", {})
 
 


### PR DESCRIPTION
Problem: AWS is running an older version of python causing datetime.toIsoFormat() to fail when the utc time had a trailing Z which corresponds to +00:00

Solution: replace Z with +00:00 for that check

Changes: 
- Added a str replace to change Z to +00:00 since older versions of python don't support isofromat conversions with the Z.
- Added error handling so that one bad report will not stop all reports from being ingested which caused old data to remain in the dynamoDB 
- Also changed list comprehension to a for loop for computation efficiency and readability.
- Removed Debug print statements from last commit